### PR TITLE
Added sitemap

### DIFF
--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+export async function GET() {
+  const baseUrl = "https://whythe.app";
+
+  const filePath = path.join(process.cwd(), "validPaths.json");
+  const rawData = readFileSync(filePath, "utf8");
+  const routes: string[] = JSON.parse(rawData);
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${routes
+  .map(
+    (url) => `
+  <url>
+    <loc>${baseUrl}${url}</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>`
+  )
+  .join("")}
+</urlset>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  });
+}


### PR DESCRIPTION
This pull request introduces a new feature to dynamically generate a sitemap in XML format for the application. The `GET` function in `src/app/sitemap.xml/route.ts` reads valid paths from a JSON file and constructs an XML sitemap with predefined attributes.

### New Feature: Dynamic Sitemap Generation
* Added a `GET` function in `src/app/sitemap.xml/route.ts` to generate a sitemap in XML format. The function reads valid paths from a `validPaths.json` file, constructs the sitemap with a base URL, and sets attributes like `changefreq` and `priority` for each route.