### PR TITLE
Added slugs for articles

### DIFF
--- a/src/CONSTANTS/article.constants.ts
+++ b/src/CONSTANTS/article.constants.ts
@@ -1,5 +1,6 @@
 export type Article = {
   articleId: number;
+  slug: string;
   title: string;
   content: string;
   author: string;

--- a/src/app/home/articles/[articleId]/ArticleViewer.server.render.tsx
+++ b/src/app/home/articles/[articleId]/ArticleViewer.server.render.tsx
@@ -10,15 +10,16 @@ export default async function ArticlesServer() {
     headersList.get("x-pathname") || headersList.get("next-url") || "";
 
   const pathParts = pathname.split("/");
-  const articleId =
+  const articleIdOrSlug =
     pathParts[pathParts.length - 1] !== "articles"
       ? pathParts[pathParts.length - 1]
       : null;
 
-  const url =
-    articleId != null && articleId != ""
-      ? `${baseUrl}articles/get-article?articleId=${articleId}`
-      : `${baseUrl}articles/get-featured`;
+  const isNumeric = /^\d+$/.test(articleIdOrSlug!);
+
+  const url = isNumeric
+    ? `${baseUrl}articles/get-article?articleId=${articleIdOrSlug}`
+    : `${baseUrl}articles/get-article?slug=${articleIdOrSlug}`;
 
   let currentArticle: Article;
 

--- a/src/components/article-card/ArticleCard.render.tsx
+++ b/src/components/article-card/ArticleCard.render.tsx
@@ -21,7 +21,7 @@ const ArticleCard = (article: Article) => {
   const router = useRouter();
 
   const navigateToArticle = () => {
-    router.push("/home/articles/" + article.articleId);
+    router.push("/home/articles/" + article.slug);
   };
 
   const moreAction = () => {
@@ -30,7 +30,7 @@ const ArticleCard = (article: Article) => {
 
   const copyLink = async () => {
     await navigator.clipboard.writeText(
-      "https://whythe.app/home/articles/" + article.articleId
+      "https://whythe.app/home/articles/" + article.slug
     );
 
     setPopup(false);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,33 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import validPaths from "../validPaths.json";
 
-export function middleware(request: NextRequest) {
+let cachedSlugMap: Record<string, string> = {};
+let lastLoadTime = 0;
+const cacheDurationMs = 30 * 1000;
+
+async function loadSlugMap() {
+  const now = Date.now();
+  if (!cachedSlugMap || now - lastLoadTime > cacheDurationMs) {
+    try {
+      const backendUrl = process.env.NEXT_PUBLIC_API_URL;
+
+      const res = await fetch(`${backendUrl}articles/get-slug-map`);
+
+      const retrievedSlugMap: { id: number; slug: string }[] = await res.json();
+
+      for (const { id, slug } of retrievedSlugMap) {
+        cachedSlugMap[id.toString()] = slug;
+      }
+      lastLoadTime = now;
+    } catch (err) {
+      console.error("❌ Failed to fetch slug map in middleware:", err);
+      cachedSlugMap = {};
+    }
+  }
+  return cachedSlugMap!;
+}
+
+export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   const response = NextResponse.next();
@@ -23,10 +49,22 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
-  const articleDynamicMatch = /^\/home\/articles\/\d+$/;
-  if (articleDynamicMatch.test(pathname)) {
+  const articleIdMatch = pathname.match(/^\/home\/articles\/(\d+)$/);
+  if (articleIdMatch) {
+    const id = articleIdMatch[1];
+    console.log(cachedSlugMap);
+    await loadSlugMap();
+    const slug = cachedSlugMap![id];
+    if (slug) {
+      const url = request.nextUrl.clone();
+      url.pathname = `/home/articles/${slug}`;
+      return NextResponse.redirect(url);
+    }
     return response;
   }
+
+  const articleSlugMatch = /^\/home\/articles\/[a-zA-Z0-9-]+$/;
+  if (articleSlugMatch.test(pathname)) return response;
   const articleEditDynamicMatch = /^\/home\/articles\/edit\/\d+$/;
   if (articleEditDynamicMatch.test(pathname)) {
     return response;


### PR DESCRIPTION
This pull request introduces significant changes to support article slugs alongside numeric IDs for improved URL readability and flexibility. The updates span multiple files and include adjustments to the article model, routing logic, and middleware caching.

### Changes to support article slugs:

#### Article model updates:
* Added a `slug` property to the `Article` type definition in `src/CONSTANTS/article.constants.ts`.

#### Routing logic updates:
* Updated `ArticleViewer.server.render.tsx` to determine whether the article identifier is numeric or a slug, and construct the appropriate API request URL based on the identifier type. ([src/app/home/articles/[articleId]/ArticleViewer.server.render.tsxL13-R22](diffhunk://#diff-6032e21c2fb66c31f0cd65bdf4ecd6ea2d216ec065f6f1684755cf40a3c1358fL13-R22))
* Modified `ArticleCard.render.tsx` to use the `slug` property instead of `articleId` for navigation and link copying functionality. [[1]](diffhunk://#diff-3f418d615c6c925e5094f392bf55cdcb4f4d75deac07b461eb59643eb7bc66efL24-R24) [[2]](diffhunk://#diff-3f418d615c6c925e5094f392bf55cdcb4f4d75deac07b461eb59643eb7bc66efL33-R33)

#### Sitemap generation:
* Replaced the previous logic for generating article routes based on numeric IDs with logic that uses slugs fetched from the backend. Added a new environment variable `NEXT_PUBLIC_API_URL` for backend API requests.

#### Middleware caching:
* Implemented caching for the slug map in `src/middleware.ts` to optimize performance. The cache updates every 30 seconds, and the middleware redirects numeric article URLs to their corresponding slug-based URLs. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L5-R31) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L26-R67)