### PR TITLE
Hotfix: fixed hardwritten localhost

### DIFF
--- a/src/services/Authentication.service.ts
+++ b/src/services/Authentication.service.ts
@@ -37,7 +37,7 @@ export const AuthWithGoogle = async () => {
 
   const params = new URLSearchParams({
     client_id: process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID!,
-    redirect_uri: "http://localhost:3000/auth/callback",
+    redirect_uri: window.location.origin + "/auth/callback",
     response_type: "code",
     scope: "openid profile email",
     code_challenge_method: "S256",


### PR DESCRIPTION
This pull request includes a small but important change to the `AuthWithGoogle` function in `src/services/Authentication.service.ts`. The change updates the `redirect_uri` to dynamically use the current `window.location.origin` instead of the hardcoded `http://localhost:3000`. This ensures the redirect URI works correctly in different environments.